### PR TITLE
Added option subTxt to search in subelement

### DIFF
--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -27,11 +27,12 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	input.change(function() {
 		// var startTime = new Date().getTime();
 		var filter = input.val().toLowerCase();
-		var li;
+		var li, txt;
 		var numShown = 0;
 		for (var i = 0; i < len; i++) {
 			li = lis[i];
-			if ((li.textContent || li.innerText || "").toLowerCase().indexOf(filter) >= 0) {
+			txt = options.subTxt ? $(li).find(options.subTxt).text() || "" : (li.textContent || li.innerText || "");
+			if (txt.toLowerCase().indexOf(filter) >= 0) {
 				if (li.style.display == "none") {
 					li.style.display = oldDisplay;
 				}


### PR DESCRIPTION
I needed to search in a subelement of my li instead of simple li text
So I added an option 'subTxt' which get a selector for children of li where we search
For example, if li contains a span with .info class, you specify {subTxt: '.info'} in options in order to filter with this span content text
Useful for complex li content (but surely slower because of jQuery find() function)
