### PR TITLE
Added functionality to allow an ignore class

### DIFF
--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -1,5 +1,5 @@
 /**
- * fastLiveFilter jQuery plugin 1.0.3
+ * fastLiveFilter jQuery plugin 1.1.0
  * 
  * Copyright (c) 2011, Anthony Bush
  * License: <http://www.opensource.org/licenses/bsd-license.php>
@@ -13,7 +13,7 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	var input = this;
 	var timeout = options.timeout || 0;
 	var callback = options.callback || function() {};
-	
+	var ignore = options.ignore || 'filter-ignore';
 	var keyTimeout;
 	
 	// NOTE: because we cache lis & len here, users would need to re-init the plugin
@@ -31,7 +31,7 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 		var numShown = 0;
 		for (var i = 0; i < len; i++) {
 			li = lis[i];
-			if ((li.textContent || li.innerText || "").toLowerCase().indexOf(filter) >= 0) {
+			if (($(li).children(":not(." + ignore + ")").text() || "").toLowerCase().indexOf(filter) >= 0) {
 				if (li.style.display == "none") {
 					li.style.display = oldDisplay;
 				}


### PR DESCRIPTION
You can add an ignore to the options that allows the filter to ignore
children that have that class. The ignore defaults to filter-ignore. To
support this changed to use the jQuery.text() function.
I implemented this to allow the filter to be used on a table and still restrict certain table elements from being included in the filter. There may well be a better way to do this but this gave me what I wanted and I thought it might be useful. This is my first Git pull request so I probably did it wrong and for that I am sorry.
