### PR TITLE
Change the functionality to allow filtering on a table and restrict elements from the filter

### DIFF
--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -31,7 +31,7 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 		var numShown = 0;
 		for (var i = 0; i < len; i++) {
 			li = lis[i];
-			if (($(li).children(":not(." + ignore + ")").text() || "").toLowerCase().indexOf(filter) >= 0) {
+			if (($(li).contents(":not(." + ignore + ")").text() || "").toLowerCase().indexOf(filter) >= 0) {
 				if (li.style.display == "none") {
 					li.style.display = oldDisplay;
 				}

--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -1,5 +1,5 @@
 /**
- * fastLiveFilter jQuery plugin 1.0.3
+ * fastLiveFilter jQuery plugin 1.1.0
  * 
  * Copyright (c) 2011, Anthony Bush
  * License: <http://www.opensource.org/licenses/bsd-license.php>
@@ -13,7 +13,7 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	var input = this;
 	var timeout = options.timeout || 0;
 	var callback = options.callback || function() {};
-	
+	var ignore = options.ignore || 'filter-ignore';
 	var keyTimeout;
 	
 	// NOTE: because we cache lis & len here, users would need to re-init the plugin
@@ -31,7 +31,7 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 		var numShown = 0;
 		for (var i = 0; i < len; i++) {
 			li = lis[i];
-			if ((li.textContent || li.innerText || "").toLowerCase().indexOf(filter) >= 0) {
+			if (($(li).children(":not(." + ignore + ")").text() || "").toLowerCase().indexOf(filter) >= 0) {
 				if (li.style.display == "none") {
 					li.style.display = oldDisplay;
 				}

--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -31,7 +31,7 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 		var numShown = 0;
 		for (var i = 0; i < len; i++) {
 			li = lis[i];
-			if (($(li).contents(":not(." + ignore + ")").text() || "").toLowerCase().indexOf(filter) >= 0) {
+			if ((jQuery(li).contents(":not(." + ignore + ")").text() || "").toLowerCase().indexOf(filter) >= 0) {
 				if (li.style.display == "none") {
 					li.style.display = oldDisplay;
 				}


### PR DESCRIPTION
There is a new input on the options ignore that allows you to ignore elements in a table using a class. The rest of the functionality stayed the same. The ignore defaults to the class filter-ignore but you can set it to any class you want. You just pass the class name in the options under the ignore like {ignore: 'a-class-to-ignore'}.
