### PR TITLE
Custom selector and fix for change event

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Available options:
 
 - timeout: How many milliseconds to wait after keydown before filtering the list.  Default is 0.
 - callback: A callback method which will be given the number of items left in the list.
+- selector: By default, the plugin will match the filter against the text of the `li`. If specifed, the selector will be applied to the `li` and the resulting text will be used instead. **WARNING:** Use of complex selectors may reduce performance significantly, especially in large lists!
 
 Example:
 

--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -34,7 +34,7 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 			li = lis[i];
 			innerText = !options.selector ? 
 				(li.textContent || li.innerText || "") : 
-				$(li).addBack().find(options.selector).text();
+				$(li).find(options.selector).text();
 			
 			if (innerText.toLowerCase().indexOf(filter) >= 0) {
 				if (li.style.display == "none") {

--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -11,6 +11,7 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	options = options || {};
 	list = jQuery(list);
 	var input = this;
+	var lastFilter = '';
 	var timeout = options.timeout || 0;
 	var callback = options.callback || function() {};
 	
@@ -47,11 +48,12 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 		// console.log('Search for ' + filter + ' took: ' + (endTime - startTime) + ' (' + numShown + ' results)');
 		return false;
 	}).keydown(function() {
-		// TODO: one point of improvement could be in here: currently the change event is
-		// invoked even if a change does not occur (e.g. by pressing a modifier key or
-		// something)
 		clearTimeout(keyTimeout);
-		keyTimeout = setTimeout(function() { input.change(); }, timeout);
+		keyTimeout = setTimeout(function() {
+			if( input.val() === lastFilter ) return;
+			lastFilter = input.val();
+			input.change();
+		}, timeout);
 	});
 	return this; // maintain jQuery chainability
 }

--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -28,11 +28,15 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	input.change(function() {
 		// var startTime = new Date().getTime();
 		var filter = input.val().toLowerCase();
-		var li;
+		var li, innerText;
 		var numShown = 0;
 		for (var i = 0; i < len; i++) {
 			li = lis[i];
-			if ((li.textContent || li.innerText || "").toLowerCase().indexOf(filter) >= 0) {
+			innerText = !options.selector ? 
+				(li.textContent || li.innerText || "") : 
+				$(li).addBack().find(options.selector).text();
+			
+			if (innerText.toLowerCase().indexOf(filter) >= 0) {
 				if (li.style.display == "none") {
 					li.style.display = oldDisplay;
 				}


### PR DESCRIPTION
859a7ae fixes your todo item at the bottom. It shouldn't affect speed since nothing in the loop changed.

01f76c5 adds a custom selector option, similar to what was suggested in #6.

I've modified the code for clarity and tested it on a list of about 2,100 items. Compared to the original version, there appears to be no noticeable difference when a selector is not specified (i.e. the default, backwards-compatible behavior). As expected, however, there is a nominal performance hit when using a selector. (I've noted this in the readme for prospective users.)

I believe this will be useful for a lot of people. My use case is something like this:

``` html
<ul>
    <li>
        <span class="badge">Badge Text</span>
        <span class="description">Description</span>
    </li>
</ul>
```

By default, the filter will compare against `Badge TextDescription`, which is undesirable. But when `.description` is used as a selector, the plugin compares only against `Description`, which is the desired behavior.

7ad6fcd removes the use of `addback()`, which was benign but unnecessary and would have made the plugin incompatible with jQuery < 1.8.
