### PR TITLE
added support for filtering elements by a specified attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Available options:
 - timeout: How many milliseconds to wait after keydown before filtering the list.  Default is 0.
 - callback: A callback method which will be given the number of items left in the list.
 - selector: By default, the plugin will match the filter against the text of the `li`. If specifed, the selector will be applied to the `li` and the resulting text will be used instead. **WARNING:** Use of complex selectors may reduce performance significantly, especially in large lists!
+- filterAttribute: An attribute of the matched element (li or otherwise) to use for filtering the item, instead of using the visible text.
 
 Example:
 

--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -28,13 +28,16 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	input.change(function() {
 		// var startTime = new Date().getTime();
 		var filter = input.val().toLowerCase();
-		var li, innerText;
+		var li, elem, innerText;
 		var numShown = 0;
 		for (var i = 0; i < len; i++) {
 			li = lis[i];
-			innerText = !options.selector ? 
-				(li.textContent || li.innerText || "") : 
-				$(li).find(options.selector).text();
+			elem = options.selector ? 
+				$(li).find(options.selector) : 
+				$(li)
+			innerText = options.filterAttribute ? 
+				elem.attr(options.filterAttribute) : 
+				elem.text();
 			
 			if (innerText.toLowerCase().indexOf(filter) >= 0) {
 				if (li.style.display == "none") {


### PR DESCRIPTION
This allows you to pass `filterAttribute` to the fastLiveFilter initializer, and filter by a specified element attribute. I needed more control over what I was filtering over, so my elements have `data-filter-text` attributes that we populate, and then we pass the attribute name to .fastLiveFilter
