### PR TITLE
Fix issue when refreshing a page

### DIFF
--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -23,7 +23,6 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	var lis = list.children();
 	var len = lis.length;
 	var oldDisplay = len > 0 ? lis[0].style.display : "block";
-	callback(len); // do a one-time callback on initialization to make sure everything's in sync
 	
 	input.change(function() {
 		// var startTime = new Date().getTime();
@@ -59,5 +58,8 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 			input.change();
 		}, timeout);
 	});
+	
+	input.triggerHandler('keydown'); // do a one-time initialization to make sure everything's in sync
+	
 	return this; // maintain jQuery chainability
 }


### PR DESCRIPTION
Hi Anthony

This is my first pull request so I hope I'm doing this right.

Recently I used fastLiveFilter in a project I'm working on and discovered an issue. When refreshing the page, in Firefox at least (not a hard refresh), the input value stayed the same. The issue was that fastLiveFilter outputted the same as for an empty input. The callback function was called but the resulting list was unchanged / unfiltered.

The fix here removes the callback(len); line and adds a triggerHandler to initialise. It worked for me. When the page was refreshed fastLiveFilter checked the current value of the input and did its fab thing.

all the best
Dave
