### PR TITLE
Added hideOnInit and hideIfEmpty options; Formatted Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ Available options:
 - timeout: How many milliseconds to wait after keydown before filtering the list.  Default is 0.
 - callback: A callback method which will be given the number of items left in the list.
 - selector: By default, the plugin will match the filter against the text of the `li`. If specifed, the selector will be applied to the `li` and the resulting text will be used instead. **WARNING:** Use of complex selectors may reduce performance significantly, especially in large lists!
+- hideOnInit: true/false; Hides all the list items after initialization. Default: false
 
 Example:
 
 	$('#search_input').fastLiveFilter('#search_list', {
 		timeout: 200,
-		callback: function(total) { $('#num_results').html(total); }
+		callback: function(total) { $('#num_results').html(total); },
+		hideOnInit: true
 	});
 
 Problems? Want to contribute?

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Available options:
 - callback: A callback method which will be given the number of items left in the list.
 - selector: By default, the plugin will match the filter against the text of the `li`. If specifed, the selector will be applied to the `li` and the resulting text will be used instead. **WARNING:** Use of complex selectors may reduce performance significantly, especially in large lists!
 - hideOnInit: true/false; Hides all the list items after initialization. Default: false
+- hideIfEmpty: true/false; Hides all list items if the search field is empty. Default: false
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -7,47 +7,53 @@ Usage
 -----
 
 Include jQuery, the plugin, then initialize the plugin:
-
-	<script src="jquery-1.6.4.min.js"></script>
-	<script src="jquery.fastLiveFilter.js"></script>
-	<script>
-		$(function() {
-			$('#search_input').fastLiveFilter('#search_list');
-		});
-	</script>
+```html
+<script src="jquery-1.6.4.min.js"></script>
+<script src="jquery.fastLiveFilter.js"></script>
+<script>
+	$(function() {
+		$('#search_input').fastLiveFilter('#search_list');
+	});
+</script>
+```
 
 The above would work with this HTML:
-
-	<input id="search_input" placeholder="Type to filter">
-	<ul id="search_list">
-		<li>One</li>
-		<li>Two</li>
-		<li>Three</li>
-	</ul>
+```html
+<input id="search_input" placeholder="Type to filter">
+<ul id="search_list">
+	<li>One</li>
+	<li>Two</li>
+	<li>Three</li>
+</ul>
+```
 
 Options
 -------
 
 Options are given as the second argument. Synopsis:
-
-	$(INPUT_SELECTOR).fastLiveFilter(LIST_SELECTOR, options);
+```javascript
+$(INPUT_SELECTOR).fastLiveFilter(LIST_SELECTOR, options);
+```
 
 Available options:
 
-- timeout: How many milliseconds to wait after keydown before filtering the list.  Default is 0.
-- callback: A callback method which will be given the number of items left in the list.
-- selector: By default, the plugin will match the filter against the text of the `li`. If specifed, the selector will be applied to the `li` and the resulting text will be used instead. **WARNING:** Use of complex selectors may reduce performance significantly, especially in large lists!
-- hideOnInit: true/false; Hides all the list items after initialization. Default: false
-- hideIfEmpty: true/false; Hides all list items if the search field is empty. Default: false
+Option | Type | Default | Description
+------ | ---- | ------- | -----------
+timeout | integer | 0 | How many milliseconds to wait after keydown before filtering the list
+hideOnInit | boolean | false | Hides all the list items after initialization
+hideIfEmpty | boolean | false | Hides all list items if the search field is empty
+callback | function | none | A callback method which will be given the number of items left in the list
+selector | jQuery selector | text of `li` | By default, the plugin will match the filter against the text of the `li`. If specifed, the selector will be applied to the `li` and the resulting text will be used instead. **WARNING:** Use of complex selectors may reduce performance significantly, especially in large lists!
 
 Example:
-
-	$('#search_input').fastLiveFilter('#search_list', {
-		timeout: 200,
-		callback: function(total) { $('#num_results').html(total); },
-		hideOnInit: true
-	});
-
+```javascript
+$('#search_input').fastLiveFilter('#search_list', {
+	timeout: 200,
+	hideOnInit: true,
+	hideIfEmpty: true,
+	callback: function(total) { $('#num_results').html(total); }
+});
+```
 Problems? Want to contribute?
 -----------------------------
 

--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -14,7 +14,7 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	var lastFilter = '';
 	var timeout = options.timeout || 0;
 	var callback = options.callback || function() {};
-	
+	var hideOnInit = options.hideOnInit || false;
 	var keyTimeout;
 	
 	// NOTE: because we cache lis & len here, users would need to re-init the plugin
@@ -23,7 +23,9 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	var lis = list.children();
 	var len = lis.length;
 	var oldDisplay = len > 0 ? lis[0].style.display : "block";
+	if(hideOnInit) { list[i].each(function() { this.style.display = "none"; }); }
 	callback(len); // do a one-time callback on initialization to make sure everything's in sync
+	
 	
 	input.change(function() {
 		// var startTime = new Date().getTime();

--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -24,13 +24,16 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	var lis = list.children();
 	var len = lis.length;
 	var oldDisplay = len > 0 ? lis[0].style.display : "block";
-	if(hideOnInit) {
+	if (hideOnInit) {
 		lis.each(function() {
 			this.style.display = "none";
 		});
 	}
-	callback(len); // do a one-time callback on initialization to make sure everything's in sync
-	
+	if (hideIfEmpty && !$.trim(this.value).length) {
+		callback(0); // return the correct value of 0 if the search field is empty upon init
+	} else {
+		callback(len); // do a one-time callback on initialization to make sure everything's in sync
+	}
 	
 	input.change(function() {
 		// var startTime = new Date().getTime();
@@ -67,7 +70,7 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	}).keydown(function() {
 		clearTimeout(keyTimeout);
 		keyTimeout = setTimeout(function() {
-			if( input.val() === lastFilter ) return;
+			if (input.val() === lastFilter) return;
 			lastFilter = input.val();
 			input.change();
 		}, timeout);

--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -15,6 +15,7 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	var timeout = options.timeout || 0;
 	var callback = options.callback || function() {};
 	var hideOnInit = options.hideOnInit || false;
+	var hideIfEmpty = options.hideIfEmpty || false;
 	var keyTimeout;
 	
 	// NOTE: because we cache lis & len here, users would need to re-init the plugin
@@ -33,23 +34,29 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	
 	input.change(function() {
 		// var startTime = new Date().getTime();
+		var numShown = 0;
 		var filter = input.val().toLowerCase();
 		var li, innerText;
-		var numShown = 0;
-		for (var i = 0; i < len; i++) {
-			li = lis[i];
-			innerText = !options.selector ? 
-				(li.textContent || li.innerText || "") : 
-				$(li).find(options.selector).text();
-			
-			if (innerText.toLowerCase().indexOf(filter) >= 0) {
-				if (li.style.display == "none") {
-					li.style.display = oldDisplay;
-				}
-				numShown++;
-			} else {
-				if (li.style.display != "none") {
-					li.style.display = "none";
+		if (hideIfEmpty && !$.trim(this.value).length) {
+			lis.each(function() {
+				this.style.display = "none";
+			});
+		} else {
+			for (var i = 0; i < len; i++) {
+				li = lis[i];
+				innerText = !options.selector ? 
+					(li.textContent || li.innerText || "") : 
+					$(li).find(options.selector).text();
+				
+				if (innerText.toLowerCase().indexOf(filter) >= 0) {
+					if (li.style.display == "none") {
+						li.style.display = oldDisplay;
+					}
+					numShown++;
+				} else {
+					if (li.style.display != "none") {
+						li.style.display = "none";
+					}
 				}
 			}
 		}

--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -29,8 +29,8 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 			this.style.display = "none";
 		});
 	}
-	if (hideIfEmpty && !$.trim(this.value).length) {
-		callback(0); // return the correct value of 0 if the search field is empty upon init
+	if (hideOnInit || (hideIfEmpty && !$.trim(this.value).length)) {
+		callback(0); // return the correct value of 0 if the search field is empty upon init or hideOnInit is true
 	} else {
 		callback(len); // do a one-time callback on initialization to make sure everything's in sync
 	}

--- a/jquery.fastLiveFilter.js
+++ b/jquery.fastLiveFilter.js
@@ -23,7 +23,11 @@ jQuery.fn.fastLiveFilter = function(list, options) {
 	var lis = list.children();
 	var len = lis.length;
 	var oldDisplay = len > 0 ? lis[0].style.display : "block";
-	if(hideOnInit) { list[i].each(function() { this.style.display = "none"; }); }
+	if(hideOnInit) {
+		lis.each(function() {
+			this.style.display = "none";
+		});
+	}
 	callback(len); // do a one-time callback on initialization to make sure everything's in sync
 	
 	


### PR DESCRIPTION
# Summary

Added 2 new options which have marginal impact on search performance

| Option | Type | Default | Description |
| --- | --- | --- | --- |
| hideOnInit | boolean | false | Hides all the list items after initialization |
| hideIfEmpty | boolean | false | Hides all list items if the search field is empty |
## hideOnInit

If set to `true`, will make _all_ child elements of the given list have its `display` style set to `none`. (Exactly how the searching makes the elements hidden as well)
## hideIfEmpty

If set to `true`, will first check if the (trimmed) input field is empty, then, like `hideOnInit`, will make _all_ child elements of the given list have its `display` style set to `none`. 
# Additional Changes

Formatted Readme to have its options placed in a tabular form, and its code blocks have appropriate syntax highlighting
